### PR TITLE
Use hostname instead of host

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ if (process.env.TIMEOUT) {
 for (const key in cacheConfig) {
     if (!Object.prototype.hasOwnProperty.call(cacheConfig, key)) continue;
     switch (key) {
-        case 'version': break;
+        case 'version':
+        case 'changeOrigin':
+            break;
         case 'xResponseTime':
             middlewares.push(RouteTimeReqRes);
             break;

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -96,7 +96,7 @@ class Proxy {
             port: this.target.port || this.port,
             method,
             headers: { ...headers },
-            host: this.target.host,
+            host: this.target.hostname,
             path: join(this.target.path, path)
         };
 


### PR DESCRIPTION
As we are adding port separately, we need to use the hostname, coz host includes port then it returns address not found.

To replicate the issue:
Set target URL with a port for eg. `http://localhost:3000/`
Now Osham server will send the request to `localhost:3000:3000/path`

Fix:
use `hostname` from `url.parse()` which doesn't have port included.